### PR TITLE
🧹 Code Health: Remove commented out companies function in Mutual model

### DIFF
--- a/Modules/AdminPanel/app/Models/Mutual.php
+++ b/Modules/AdminPanel/app/Models/Mutual.php
@@ -5,8 +5,6 @@ namespace Modules\AdminPanel\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-// use Modules\Companies\Models\Company;
-
 class Mutual extends Model
 {
     use HasFactory;
@@ -17,9 +15,4 @@ class Mutual extends Model
      * The attributes that are mass assignable.
      */
     protected $fillable = ['nombre'];
-
-    // public function companies()
-    // {
-    //     return $this->hasMany(Company::class);
-    // }
 }


### PR DESCRIPTION
🎯 **What:** Removed the commented-out `companies()` function and its unused `use` statement in `Modules/AdminPanel/app/Models/Mutual.php`.
💡 **Why:** This code was dead/commented out and served no purpose. Removing it improves the maintainability and readability of the codebase, aligning with better code health practices.
✅ **Verification:** Ran `php artisan test` after removing the commented-out lines to ensure no existing functionality or test suites were negatively impacted. All tests passed.
✨ **Result:** A cleaner `Mutual` model file without unnecessary dead code.

---
*PR created automatically by Jules for task [17860697564957617405](https://jules.google.com/task/17860697564957617405) started by @cartes*